### PR TITLE
Check if channel isInitialized before use it

### DIFF
--- a/android/src/main/kotlin/com/djamo/plugin/vgscardinfo/VgscardinfoPlugin.kt
+++ b/android/src/main/kotlin/com/djamo/plugin/vgscardinfo/VgscardinfoPlugin.kt
@@ -25,6 +25,8 @@ class VgscardinfoPlugin: FlutterPlugin, MethodCallHandler {
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-    channel.setMethodCallHandler(null)
+    if (::channel.isInitialized) {
+      channel.setMethodCallHandler(null)
+    }
   }
 }


### PR DESCRIPTION
### Changes

- [x] [Check if channel isInitialized before use it](https://github.com/djamoapp/flutter-vgs-cardinfo-plugin/commit/06c623e119b15c1cbb1b6599d7face88d1f8594b)

### Explanation
We deal with **UninitializedPropertyAccessException** in Kotlin. This exception is related to lateinit variables that have not been initialized before using them in any kind of way.

### Docs :
- https://frontbackend.com/kotlin/how-to-deal-with-uninitializedpropertyaccessexception-in-kotlin
- https://api.flutter.dev/javadoc/io/flutter/embedding/engine/plugins/[FlutterPlugin](https://api.flutter.dev/javadoc/io/flutter/embedding/engine/plugins/FlutterPlugin.html).html
